### PR TITLE
fix: display sync times in site timezone instead of UTC

### DIFF
--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -437,7 +437,7 @@ function sync_status_section_callback() {
 					<?php
 					$date_format = get_option( 'date_format' );
 					$time_format = get_option( 'time_format' );
-					$formatted_date = date_i18n( $date_format . ' ' . $time_format, $last_sync );
+					$formatted_date = wp_date( $date_format . ' ' . $time_format, $last_sync );
 					$relative_time = \Kraft\Beer_Slurper\Sync_Status\get_relative_time( $last_sync );
 					?>
 					<?php echo esc_html( $formatted_date ); ?> (<?php echo esc_html( $relative_time ); ?>)
@@ -462,7 +462,7 @@ function sync_status_section_callback() {
 					<?php
 					$date_format = get_option( 'date_format' );
 					$time_format = get_option( 'time_format' );
-					$formatted_next = date_i18n( $date_format . ' ' . $time_format, $next_sync );
+					$formatted_next = wp_date( $date_format . ' ' . $time_format, $next_sync );
 					?>
 					<?php echo esc_html( $formatted_next ); ?>
 				<?php elseif ( $user ) : ?>

--- a/includes/functions/sync-status.php
+++ b/includes/functions/sync-status.php
@@ -195,5 +195,5 @@ function get_untappd_total_checkins() {
  * @return string Human-readable relative time.
  */
 function get_relative_time( $timestamp ) {
-	return human_time_diff( $timestamp, current_time( 'timestamp' ) ) . ' ' . __( 'ago', 'beer_slurper' );
+	return human_time_diff( $timestamp, time() ) . ' ' . __( 'ago', 'beer_slurper' );
 }

--- a/tests/phpunit/Sync_Status_Tests.php
+++ b/tests/phpunit/Sync_Status_Tests.php
@@ -167,4 +167,93 @@ class Sync_Status_Tests extends Base\TestCase {
 
 		$this->assertFalse( $result );
 	}
+
+	/**
+	 * Tests get_relative_time() returns correct relative time regardless of site timezone.
+	 *
+	 * This test would have failed before the fix when get_relative_time() used
+	 * current_time('timestamp') instead of time(). The old code compared a UTC
+	 * timestamp against a timezone-adjusted value, causing incorrect results
+	 * like "5 hours ago" when the actual time was only minutes ago.
+	 */
+	public function test_get_relative_time_uses_utc_comparison() {
+		// Set site to UTC-5 (Eastern Standard Time offset)
+		update_option( 'gmt_offset', -5 );
+
+		// Create a timestamp for 10 minutes ago (in UTC, which is what we store)
+		$ten_minutes_ago = time() - ( 10 * MINUTE_IN_SECONDS );
+
+		$result = get_relative_time( $ten_minutes_ago );
+
+		// The result should say "10 mins ago", not "5 hours ago"
+		// With the old buggy code using current_time('timestamp'), this would fail
+		// because current_time('timestamp') returns time() + (gmt_offset * HOUR_IN_SECONDS)
+		// which for UTC-5 would be 5 hours behind, making the diff ~5 hours instead of 10 mins
+		$this->assertStringContainsString( 'min', $result, 'Relative time should be in minutes, not hours' );
+		$this->assertStringContainsString( 'ago', $result );
+		$this->assertStringNotContainsString( 'hour', $result, 'Should not show hours for a 10-minute-old timestamp' );
+	}
+
+	/**
+	 * Tests get_relative_time() with positive timezone offset.
+	 *
+	 * Verifies correct behavior for sites east of UTC (e.g., UTC+5).
+	 * This would also fail with the old current_time('timestamp') approach.
+	 */
+	public function test_get_relative_time_with_positive_offset() {
+		// Set site to UTC+5
+		update_option( 'gmt_offset', 5 );
+
+		// Create a timestamp for 5 minutes ago (in UTC)
+		$five_minutes_ago = time() - ( 5 * MINUTE_IN_SECONDS );
+
+		$result = get_relative_time( $five_minutes_ago );
+
+		// Should show minutes, not hours
+		$this->assertStringContainsString( 'min', $result );
+		$this->assertStringContainsString( 'ago', $result );
+		$this->assertStringNotContainsString( 'hour', $result );
+	}
+
+	/**
+	 * Tests get_relative_time() calculates correctly for longer durations.
+	 *
+	 * Verifies the function works correctly for timestamps hours ago,
+	 * ensuring the timezone offset doesn't compound the error.
+	 */
+	public function test_get_relative_time_hours_ago_with_offset() {
+		// Set site to UTC-8 (Pacific)
+		update_option( 'gmt_offset', -8 );
+
+		// Create a timestamp for exactly 2 hours ago
+		$two_hours_ago = time() - ( 2 * HOUR_IN_SECONDS );
+
+		$result = get_relative_time( $two_hours_ago );
+
+		// Should show "2 hours ago", not "10 hours ago" (2 + 8 offset)
+		$this->assertStringContainsString( 'hour', $result );
+		$this->assertStringContainsString( 'ago', $result );
+		// Extract the number - should be around 2, not 10
+		preg_match( '/(\d+)\s*hour/', $result, $matches );
+		$this->assertNotEmpty( $matches, 'Should contain a number of hours' );
+		$hours = (int) $matches[1];
+		$this->assertLessThanOrEqual( 2, $hours, 'Should show approximately 2 hours, not offset-adjusted time' );
+	}
+
+	/**
+	 * Tests get_relative_time() works correctly with UTC timezone.
+	 *
+	 * Baseline test to ensure function works when site is set to UTC.
+	 */
+	public function test_get_relative_time_with_utc_timezone() {
+		// Set site to UTC (no offset)
+		update_option( 'gmt_offset', 0 );
+
+		$thirty_minutes_ago = time() - ( 30 * MINUTE_IN_SECONDS );
+
+		$result = get_relative_time( $thirty_minutes_ago );
+
+		$this->assertStringContainsString( 'min', $result );
+		$this->assertStringContainsString( 'ago', $result );
+	}
 }


### PR DESCRIPTION
- Use wp_date() instead of date_i18n() for last sync and next sync times,
  which properly converts UTC timestamps to the site's timezone
- Use time() instead of current_time('timestamp') in get_relative_time()
  to correctly calculate relative time from UTC timestamps

The stored timestamps remain in UTC; only the display is corrected.

https://claude.ai/code/session_01SkuGxYsPrrrtqgso7C5FSK