### PR TITLE
feat: rate-limit prime-queue and backfill-companions CLI commands

### DIFF
--- a/includes/functions/cli.php
+++ b/includes/functions/cli.php
@@ -369,6 +369,7 @@ class Beer_Slurper_Command extends \WP_CLI_Command {
 			$items = $response['checkins']['items'];
 			$count = count( $items );
 			$page_matched = 0;
+			$page_companions = 0;
 
 			foreach ( $items as $checkin ) {
 				$cid = (string) $checkin['checkin_id'];
@@ -387,6 +388,7 @@ class Beer_Slurper_Command extends \WP_CLI_Command {
 
 				$friend_count = count( $checkin['tagged_friends']['items'] );
 				$companions  += $friend_count;
+				$page_companions += $friend_count;
 
 				if ( $dry_run ) {
 					\WP_CLI::log( sprintf(
@@ -424,11 +426,11 @@ class Beer_Slurper_Command extends \WP_CLI_Command {
 			}
 
 			\WP_CLI::log( sprintf(
-				'Page %d: fetched %d, matched %d local, %d with companions',
+				'Page %d: fetched %d, matched %d local, %d companions on page',
 				$page,
 				$count,
 				$page_matched,
-				$companions > 0 ? $companions : 0
+				$page_companions
 			) );
 
 			// Update pagination cursor.

--- a/includes/functions/cli.php
+++ b/includes/functions/cli.php
@@ -233,18 +233,26 @@ class Beer_Slurper_Command extends \WP_CLI_Command {
 	 * local beer posts. The checkin/view endpoint does NOT return tagged
 	 * friends, so this is the only way to backfill.
 	 *
+	 * By default, schedules page fetches via Action Scheduler to respect
+	 * API rate limits. Use --sync to run immediately (may exhaust budget).
+	 *
 	 * ## OPTIONS
 	 *
 	 * [--pages=<number>]
 	 * : Maximum pages to fetch (25 checkins each). Default: unlimited.
 	 *
+	 * [--sync]
+	 * : Run synchronously instead of scheduling via Action Scheduler.
+	 *   Warning: may exhaust API budget quickly.
+	 *
 	 * [--dry-run]
-	 * : Show what would be attached without making changes.
+	 * : Show what would be attached without making changes (implies --sync).
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp beer-slurper backfill-companions
 	 *     wp beer-slurper backfill-companions --pages=10
+	 *     wp beer-slurper backfill-companions --sync
 	 *     wp beer-slurper backfill-companions --dry-run
 	 *
 	 * @subcommand backfill-companions
@@ -260,6 +268,7 @@ class Beer_Slurper_Command extends \WP_CLI_Command {
 
 		$max_pages = isset( $assoc_args['pages'] ) ? (int) $assoc_args['pages'] : 0;
 		$dry_run   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
+		$sync      = \WP_CLI\Utils\get_flag_value( $assoc_args, 'sync', false ) || $dry_run;
 
 		// Build a lookup of checkin_id => post_id from existing checkin comments.
 		$rows = $wpdb->get_results(
@@ -280,12 +289,57 @@ class Beer_Slurper_Command extends \WP_CLI_Command {
 			return;
 		}
 
-		\WP_CLI::log( sprintf( 'Found %d local checkins. Fetching from Untappd...', count( $checkin_to_post ) ) );
+		\WP_CLI::log( sprintf( 'Found %d local checkins.', count( $checkin_to_post ) ) );
+
+		// Use Action Scheduler for rate-limited execution unless --sync is specified.
+		if ( ! $sync ) {
+			$session_id = substr( md5( uniqid( 'backfill', true ) ), 0, 8 );
+			$remaining  = \Kraft\Beer_Slurper\Queue\get_remaining_budget();
+			$params     = \Kraft\Beer_Slurper\Queue\get_page_spread_params();
+
+			\WP_CLI::log( '' );
+			\WP_CLI::log( sprintf( 'API budget remaining: %d calls', $remaining ) );
+			\WP_CLI::log( sprintf( 'Rate: %d pages/hour (%ds between pages)', $params['per_hour'], $params['interval'] ) );
+
+			if ( $max_pages > 0 ) {
+				$hours_needed = ceil( $max_pages / $params['per_hour'] );
+				\WP_CLI::log( sprintf( 'Estimated time for %d pages: ~%d hour(s)', $max_pages, $hours_needed ) );
+			} else {
+				\WP_CLI::log( 'Pages: unlimited (will process until end of history)' );
+			}
+
+			\WP_CLI::log( '' );
+			\WP_CLI::log( 'Scheduling first page fetch...' );
+
+			\Kraft\Beer_Slurper\Queue\schedule_action(
+				'bs_backfill_companions_page',
+				array(
+					'user'       => $user,
+					'page'       => 1,
+					'max_pages'  => $max_pages,
+					'session_id' => $session_id,
+					'max_id'     => null,
+				),
+				0
+			);
+
+			\WP_CLI::success( sprintf(
+				'Backfill companions job scheduled (session: %s). Progress will be logged to error_log.',
+				$session_id
+			) );
+			\WP_CLI::log( 'Run `wp action-scheduler run` to process immediately, or wait for WP-Cron.' );
+			return;
+		}
+
+		// Synchronous mode (original behavior).
+		\WP_CLI::log( 'Running in synchronous mode. Fetching from Untappd...' );
 
 		$page       = 0;
 		$max_id     = null;
 		$matched    = 0;
 		$companions = 0;
+		$attached   = 0;
+		$skipped    = 0;
 
 		while ( true ) {
 			$page++;
@@ -314,6 +368,7 @@ class Beer_Slurper_Command extends \WP_CLI_Command {
 
 			$items = $response['checkins']['items'];
 			$count = count( $items );
+			$page_matched = 0;
 
 			foreach ( $items as $checkin ) {
 				$cid = (string) $checkin['checkin_id'];
@@ -324,6 +379,7 @@ class Beer_Slurper_Command extends \WP_CLI_Command {
 
 				$post_id = $checkin_to_post[ $cid ];
 				$matched++;
+				$page_matched++;
 
 				if ( empty( $checkin['tagged_friends']['items'] ) ) {
 					continue;
@@ -340,11 +396,40 @@ class Beer_Slurper_Command extends \WP_CLI_Command {
 						$friend_count
 					) );
 				} else {
-					\Kraft\Beer_Slurper\Companion\attach_companions( $checkin, $post_id );
+					// Track individual attachment success/failure.
+					foreach ( $checkin['tagged_friends']['items'] as $item ) {
+						if ( empty( $item['user']['uid'] ) ) {
+							$skipped++;
+							continue;
+						}
+
+						$term_id = \Kraft\Beer_Slurper\Companion\get_companion_term_id(
+							$item['user']['uid'],
+							$item['user']
+						);
+
+						if ( $term_id ) {
+							wp_set_object_terms( $post_id, (int) $term_id, BEER_SLURPER_TAX_COMPANION, true );
+							$attached++;
+						} else {
+							$skipped++;
+							\WP_CLI::debug( sprintf(
+								'Failed to create companion for uid %s (user_name: %s)',
+								$item['user']['uid'] ?? 'unknown',
+								$item['user']['user_name'] ?? 'missing'
+							) );
+						}
+					}
 				}
 			}
 
-			\WP_CLI::log( sprintf( 'Page %d: fetched %d, matched %d local', $page, $count, $matched ) );
+			\WP_CLI::log( sprintf(
+				'Page %d: fetched %d, matched %d local, %d with companions',
+				$page,
+				$count,
+				$page_matched,
+				$companions > 0 ? $companions : 0
+			) );
 
 			// Update pagination cursor.
 			$max_id = $response['pagination']['max_id'] ?? null;
@@ -353,11 +438,9 @@ class Beer_Slurper_Command extends \WP_CLI_Command {
 				\WP_CLI::log( 'Reached end of checkin history.' );
 				break;
 			}
-
-			// Reset matched count for next page logging.
-			$matched = 0;
 		}
 
+		\WP_CLI::log( '' );
 		if ( $dry_run ) {
 			\WP_CLI::success( sprintf(
 				'Dry run complete. Would have attached %d companion(s) across %d page(s).',
@@ -366,8 +449,11 @@ class Beer_Slurper_Command extends \WP_CLI_Command {
 			) );
 		} else {
 			\WP_CLI::success( sprintf(
-				'Backfill complete. Attached %d companion(s) across %d page(s).',
+				'Backfill complete. Matched %d checkins, found %d companions, attached %d, skipped %d across %d page(s).',
+				$matched,
 				$companions,
+				$attached,
+				$skipped,
 				$page
 			) );
 		}
@@ -376,20 +462,32 @@ class Beer_Slurper_Command extends \WP_CLI_Command {
 	/**
 	 * Fetch all outstanding checkins and queue them for processing.
 	 *
-	 * Rapidly pages through the Untappd checkin history, spending API
-	 * budget on list fetches (1 call per 25 checkins) and queuing every
-	 * discovered checkin via Action Scheduler. Processing then happens
-	 * automatically over subsequent hours as budget allows.
+	 * Pages through the Untappd checkin history, spending API budget on
+	 * list fetches (1 call per 25 checkins) and queuing every discovered
+	 * checkin via Action Scheduler. Processing then happens automatically
+	 * over subsequent hours as budget allows.
+	 *
+	 * By default, schedules page fetches via Action Scheduler to respect
+	 * API rate limits. Use --sync to run immediately (may exhaust budget).
+	 *
+	 * This command also attaches companions to any already-imported checkins
+	 * found in each page, so you don't need to run backfill-companions
+	 * separately for missing companions on existing checkins.
 	 *
 	 * ## OPTIONS
 	 *
 	 * [--pages=<number>]
 	 * : Maximum pages to fetch (25 checkins each). Default: all remaining.
 	 *
+	 * [--sync]
+	 * : Run synchronously instead of scheduling via Action Scheduler.
+	 *   Warning: may exhaust API budget quickly.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp beer-slurper prime-queue
 	 *     wp beer-slurper prime-queue --pages=10
+	 *     wp beer-slurper prime-queue --sync
 	 *
 	 * @subcommand prime-queue
 	 */
@@ -401,6 +499,7 @@ class Beer_Slurper_Command extends \WP_CLI_Command {
 		}
 
 		$max_pages = isset( $assoc_args['pages'] ) ? (int) $assoc_args['pages'] : 0;
+		$sync      = \WP_CLI\Utils\get_flag_value( $assoc_args, 'sync', false );
 		$is_backfilling = \Kraft\Beer_Slurper\Sync_Status\is_backfilling( $user );
 
 		if ( ! $is_backfilling ) {
@@ -411,10 +510,54 @@ class Beer_Slurper_Command extends \WP_CLI_Command {
 			return;
 		}
 
-		\WP_CLI::log( "Fetching historical checkins for {$user}..." );
+		// Use Action Scheduler for rate-limited execution unless --sync is specified.
+		if ( ! $sync ) {
+			$session_id = substr( md5( uniqid( 'prime', true ) ), 0, 8 );
+			$remaining  = \Kraft\Beer_Slurper\Queue\get_remaining_budget();
+			$params     = \Kraft\Beer_Slurper\Queue\get_page_spread_params();
+
+			\WP_CLI::log( "Scheduling historical checkin fetch for {$user}..." );
+			\WP_CLI::log( '' );
+			\WP_CLI::log( sprintf( 'API budget remaining: %d calls', $remaining ) );
+			\WP_CLI::log( sprintf( 'Rate: %d pages/hour (%ds between pages)', $params['per_hour'], $params['interval'] ) );
+
+			if ( $max_pages > 0 ) {
+				$hours_needed = ceil( $max_pages / $params['per_hour'] );
+				\WP_CLI::log( sprintf( 'Estimated time for %d pages: ~%d hour(s)', $max_pages, $hours_needed ) );
+			} else {
+				\WP_CLI::log( 'Pages: unlimited (will process until end of history)' );
+			}
+
+			\WP_CLI::log( '' );
+			\WP_CLI::log( 'Note: This will also attach companions to any already-imported checkins found.' );
+			\WP_CLI::log( '' );
+			\WP_CLI::log( 'Scheduling first page fetch...' );
+
+			\Kraft\Beer_Slurper\Queue\schedule_action(
+				'bs_prime_queue_page',
+				array(
+					'user'       => $user,
+					'page'       => 1,
+					'max_pages'  => $max_pages,
+					'session_id' => $session_id,
+				),
+				0
+			);
+
+			\WP_CLI::success( sprintf(
+				'Prime queue job scheduled (session: %s). Progress will be logged to error_log.',
+				$session_id
+			) );
+			\WP_CLI::log( 'Run `wp action-scheduler run` to process immediately, or wait for WP-Cron.' );
+			return;
+		}
+
+		// Synchronous mode (original behavior).
+		\WP_CLI::log( "Fetching historical checkins for {$user} (synchronous mode)..." );
 
 		$total_fetched = 0;
 		$total_queued  = 0;
+		$companions_attached = 0;
 		$page          = 0;
 
 		while ( true ) {
@@ -450,30 +593,40 @@ class Beer_Slurper_Command extends \WP_CLI_Command {
 			$total_fetched += $count;
 
 			// Update pagination cursor.
-			$max_id = $checkins['pagination']['max_id'];
-			update_option( 'beer_slurper_' . $user . '_max', $max_id, false );
+			$new_max_id = $checkins['pagination']['max_id'] ?? null;
+			if ( $new_max_id ) {
+				update_option( 'beer_slurper_' . $user . '_max', $new_max_id, false );
+			}
 
 			if ( ! get_option( 'beer_slurper_' . $user . '_since' ) ) {
-				$since_url = wp_parse_args( parse_url( $checkins['pagination']['since_url'], PHP_URL_QUERY ) );
-				$since_id = intval( $since_url['min_id'] );
-				update_option( 'beer_slurper_' . $user . '_since', $since_id, false );
+				$since_url = wp_parse_args( parse_url( $checkins['pagination']['since_url'] ?? '', PHP_URL_QUERY ) );
+				$since_id = isset( $since_url['min_id'] ) ? intval( $since_url['min_id'] ) : 0;
+				if ( $since_id ) {
+					update_option( 'beer_slurper_' . $user . '_since', $since_id, false );
+				}
 			}
 
 			// Queue for processing.
 			$queued = \Kraft\Beer_Slurper\Queue\queue_checkin_batch( $items, 'import_old' );
 			$total_queued += $queued;
 
+			// Also attach companions to any already-imported checkins.
+			$attached = \Kraft\Beer_Slurper\Queue\attach_companions_to_existing( $items );
+			$companions_attached += $attached;
+
 			\WP_CLI::log( sprintf(
-				'Page %d: fetched %d checkins, queued %d (%d fetched / %d queued total)',
+				'Page %d: fetched %d checkins, queued %d, attached companions to %d existing (%d/%d/%d total)',
 				$page,
 				$count,
 				$queued,
+				$attached,
 				$total_fetched,
-				$total_queued
+				$total_queued,
+				$companions_attached
 			) );
 
 			// End of history?
-			if ( $count < 25 ) {
+			if ( $count < 25 || empty( $new_max_id ) ) {
 				\WP_CLI::log( 'Reached end of checkin history.' );
 				delete_option( 'beer_slurper_' . $user . '_import' );
 				break;
@@ -489,10 +642,11 @@ class Beer_Slurper_Command extends \WP_CLI_Command {
 		}
 
 		\WP_CLI::success( sprintf(
-			'Fetched %d checkins across %d pages, %d queued for processing.',
+			'Fetched %d checkins across %d pages, %d queued for processing, companions attached to %d existing.',
 			$total_fetched,
 			$page,
-			$total_queued
+			$total_queued,
+			$companions_attached
 		) );
 	}
 

--- a/includes/functions/companion.php
+++ b/includes/functions/companion.php
@@ -54,28 +54,49 @@ function get_companion_term_id( $uid = null, $user_data = null ) {
  * @return int|false The term ID on success, or false on failure.
  */
 function add_companion( $uid, $user_data = null ) {
-	if ( ! is_array( $user_data ) || empty( $user_data['user_name'] ) ) {
+	// Require at minimum a UID.
+	if ( empty( $uid ) ) {
 		return false;
 	}
 
+	// Normalize user_data to an array.
+	if ( ! is_array( $user_data ) ) {
+		$user_data = array();
+	}
+
+	// Build display name from available data.
 	$display_name = trim(
 		( isset( $user_data['first_name'] ) ? $user_data['first_name'] : '' ) . ' ' .
 		( isset( $user_data['last_name'] ) ? $user_data['last_name'] : '' )
 	);
+
+	// Fall back to user_name, then to UID-based placeholder.
 	if ( empty( $display_name ) ) {
-		$display_name = $user_data['user_name'];
+		$display_name = ! empty( $user_data['user_name'] )
+			? $user_data['user_name']
+			: 'Untappd User ' . $uid;
 	}
+
+	// Determine slug: prefer user_name, fall back to uid-based slug.
+	$slug = ! empty( $user_data['user_name'] )
+		? sanitize_title( $user_data['user_name'] )
+		: 'untappd-user-' . $uid;
 
 	$term = wp_insert_term(
 		$display_name,
 		BEER_SLURPER_TAX_COMPANION,
-		array( 'slug' => sanitize_title( $user_data['user_name'] ) )
+		array( 'slug' => $slug )
 	);
 
 	if ( is_wp_error( $term ) ) {
 		if ( $term->get_error_code() === 'term_exists' ) {
-			$existing = get_term_by( 'slug', sanitize_title( $user_data['user_name'] ), BEER_SLURPER_TAX_COMPANION );
+			$existing = get_term_by( 'slug', $slug, BEER_SLURPER_TAX_COMPANION );
 			if ( $existing ) {
+				// Update the UID meta in case it was missing.
+				$existing_uid = get_term_meta( $existing->term_id, 'untappd_uid', true );
+				if ( empty( $existing_uid ) ) {
+					update_term_meta( $existing->term_id, 'untappd_uid', $uid );
+				}
 				return $existing->term_id;
 			}
 		}

--- a/includes/functions/queue.php
+++ b/includes/functions/queue.php
@@ -942,12 +942,15 @@ function process_prime_queue_page( $user, $page, $max_pages, $session_id ) {
 	$option_prefix = 'beer_slurper_' . $user;
 	$state_key     = 'beer_slurper_prime_state_' . $session_id;
 
-	// Initialize or retrieve session state.
-	$state = get_option( $state_key, array(
-		'total_fetched' => 0,
-		'total_queued'  => 0,
-		'started'       => time(),
-	) );
+	// Initialize or retrieve session state (use transient for better performance).
+	$state = get_transient( $state_key );
+	if ( false === $state ) {
+		$state = array(
+			'total_fetched' => 0,
+			'total_queued'  => 0,
+			'started'       => time(),
+		);
+	}
 
 	// Check budget.
 	if ( ! has_budget( 1 ) ) {
@@ -1008,7 +1011,7 @@ function process_prime_queue_page( $user, $page, $max_pages, $session_id ) {
 	// Update state.
 	$state['total_fetched'] += $count;
 	$state['total_queued']  += $queued;
-	update_option( $state_key, $state, false );
+	set_transient( $state_key, $state, DAY_IN_SECONDS );
 
 	// Check if we've reached the end.
 	if ( $count < 25 || empty( $new_max_id ) ) {
@@ -1091,7 +1094,7 @@ function finalize_prime_queue_session( $user, $state, $state_key, $reason ) {
 		$elapsed
 	) );
 
-	delete_option( $state_key );
+	delete_transient( $state_key );
 }
 
 /**
@@ -1111,15 +1114,18 @@ function finalize_prime_queue_session( $user, $state, $state_key, $reason ) {
 function process_backfill_companions_page( $user, $page, $max_pages, $session_id, $max_id = null ) {
 	$state_key = 'beer_slurper_backfill_state_' . $session_id;
 
-	// Initialize or retrieve session state.
-	$state = get_option( $state_key, array(
-		'total_matched'    => 0,
-		'total_companions' => 0,
-		'total_attached'   => 0,
-		'total_skipped'    => 0,
-		'started'          => time(),
-		'checkin_lookup'   => null,
-	) );
+	// Initialize or retrieve session state (use transient for better performance).
+	$state = get_transient( $state_key );
+	if ( false === $state ) {
+		$state = array(
+			'total_matched'    => 0,
+			'total_companions' => 0,
+			'total_attached'   => 0,
+			'total_skipped'    => 0,
+			'started'          => time(),
+			'checkin_lookup'   => null,
+		);
+	}
 
 	// Build lookup on first page (or if not cached).
 	if ( null === $state['checkin_lookup'] ) {
@@ -1139,11 +1145,11 @@ function process_backfill_companions_page( $user, $page, $max_pages, $session_id
 
 		if ( empty( $state['checkin_lookup'] ) ) {
 			error_log( 'Beer Slurper: backfill-companions - no local checkins found.' );
-			delete_option( $state_key );
+			delete_transient( $state_key );
 			return;
 		}
 
-		update_option( $state_key, $state, false );
+		set_transient( $state_key, $state, DAY_IN_SECONDS );
 	}
 
 	// Check budget.
@@ -1223,7 +1229,7 @@ function process_backfill_companions_page( $user, $page, $max_pages, $session_id
 		$state['total_attached'] += $attached_this;
 	}
 
-	update_option( $state_key, $state, false );
+	set_transient( $state_key, $state, DAY_IN_SECONDS );
 
 	// Update pagination cursor.
 	$new_max_id = $response['pagination']['max_id'] ?? null;
@@ -1268,7 +1274,7 @@ function finalize_backfill_companions_session( $user, $state, $state_key, $reaso
 		$elapsed
 	) );
 
-	delete_option( $state_key );
+	delete_transient( $state_key );
 }
 
 /**

--- a/includes/functions/queue.php
+++ b/includes/functions/queue.php
@@ -1055,24 +1055,36 @@ function attach_companions_to_existing( $items ) {
 		return 0;
 	}
 
-	// Batch query: find all matching posts in a single query.
-	global $wpdb;
 	$checkin_ids = array_keys( $checkins_with_companions );
-	$placeholders = implode( ',', array_fill( 0, count( $checkin_ids ), '%s' ) );
 
-	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- placeholders are safe
-	$results = $wpdb->get_results( $wpdb->prepare(
-		"SELECT post_id, meta_value AS checkin_id
-		FROM {$wpdb->postmeta}
-		WHERE meta_key = '_beer_slurper_untappd_id'
-		AND meta_value IN ($placeholders)",
-		...$checkin_ids
+	// Batch query: find all matching posts using WP_Query.
+	$query = new \WP_Query( array(
+		'post_type'              => BEER_SLURPER_CPT,
+		'posts_per_page'         => -1,
+		'fields'                 => 'ids',
+		'meta_query'             => array(
+			array(
+				'key'     => '_beer_slurper_untappd_id',
+				'value'   => $checkin_ids,
+				'compare' => 'IN',
+			),
+		),
+		'no_found_rows'          => true,
+		'update_post_term_cache' => false,
 	) );
 
-	// Build lookup: checkin_id => post_id.
+	if ( empty( $query->posts ) ) {
+		return 0;
+	}
+
+	// Prime meta cache for all returned posts (single query).
+	update_postmeta_cache( $query->posts );
+
+	// Build lookup: checkin_id => post_id (meta calls hit cache).
 	$checkin_to_post = array();
-	foreach ( $results as $row ) {
-		$checkin_to_post[ $row->checkin_id ] = (int) $row->post_id;
+	foreach ( $query->posts as $post_id ) {
+		$cid = get_post_meta( $post_id, '_beer_slurper_untappd_id', true );
+		$checkin_to_post[ $cid ] = $post_id;
 	}
 
 	// Attach companions using the lookup.

--- a/includes/functions/queue.php
+++ b/includes/functions/queue.php
@@ -822,7 +822,7 @@ function maybe_accelerate_next_checkin() {
 function get_page_spread_params() {
 	$cost_per = 1; // 1 API call per page fetch.
 	$per_hour = (int) floor( API_BUDGET_PER_HOUR / $cost_per );
-	$interval = (int) floor( 3600 / $per_hour ); // 40 seconds per page.
+	$interval = (int) floor( 3600 / $per_hour ); // Seconds per page (e.g., 40 seconds with 90/hour budget).
 	$now      = time();
 
 	$window_end = get_transient( 'beer_slurper_api_window_end' );
@@ -913,7 +913,7 @@ function schedule_next_page_fetch( $hook, $args ) {
 			// If scheduled more than an hour away and we have budget, pull it closer.
 			if ( $scheduled_time > $one_hour_out && $remaining >= 1 ) {
 				reschedule_action_by_id( $row->action_id, $now + 5 );
-			} elseif ( $scheduled_time > $one_hour_out && ! $remaining ) {
+			} elseif ( $scheduled_time > $one_hour_out && $remaining < 1 ) {
 				// No budget but scheduled too far — reschedule to window reset.
 				$reset_time = $window_end ? (int) $window_end : $one_hour_out;
 				reschedule_action_by_id( $row->action_id, $reset_time );

--- a/includes/functions/queue.php
+++ b/includes/functions/queue.php
@@ -1303,8 +1303,9 @@ function cleanup() {
 	// Legacy hook names from older versions.
 	cancel_all( 'bs_as_daily_maintenance' );
 
-	// Clean up any session state options.
-	global $wpdb;
-	$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE 'beer_slurper_prime_state_%'" );
-	$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE 'beer_slurper_backfill_state_%'" );
+	// Session state transients (beer_slurper_prime_state_*, beer_slurper_backfill_state_*)
+	// are not cleaned up here because:
+	// 1. They have DAY_IN_SECONDS TTL and will self-expire
+	// 2. With object caching, transients may not be in the database
+	// 3. Direct SQL queries would miss object-cached transients
 }

--- a/includes/functions/queue.php
+++ b/includes/functions/queue.php
@@ -806,6 +806,458 @@ function maybe_accelerate_next_checkin() {
 }
 
 /**
+ * Calculates spreading parameters for page-fetch operations.
+ *
+ * Unlike get_spread_params() which calculates for checkin processing (5 API calls each),
+ * this calculates for page fetches which cost 1 API call each.
+ *
+ * @return array {
+ *     @type int $per_hour          Pages per full hourly window.
+ *     @type int $interval          Seconds between pages in a full window.
+ *     @type int $current_slots     Slots available in the active window.
+ *     @type int $current_interval  Seconds between current-window slots.
+ *     @type int $full_start        Timestamp where full-rate windows begin.
+ * }
+ */
+function get_page_spread_params() {
+	$cost_per = 1; // 1 API call per page fetch.
+	$per_hour = (int) floor( API_BUDGET_PER_HOUR / $cost_per );
+	$interval = (int) floor( 3600 / $per_hour ); // 40 seconds per page.
+	$now      = time();
+
+	$window_end = get_transient( 'beer_slurper_api_window_end' );
+	$remaining  = get_remaining_budget();
+
+	$current_slots    = 0;
+	$current_interval = $interval;
+
+	if ( $window_end && (int) $window_end > $now && $remaining >= $cost_per ) {
+		$secs_left = (int) ( (int) $window_end - $now );
+
+		$current_slots = min(
+			(int) floor( $remaining / $cost_per ),
+			(int) floor( $secs_left / $interval )
+		);
+
+		if ( $current_slots > 1 ) {
+			$current_interval = (int) floor( $secs_left / $current_slots );
+		} elseif ( 1 === $current_slots ) {
+			$current_interval = 0;
+		}
+	}
+
+	$full_start = ( $window_end && (int) $window_end > $now )
+		? (int) $window_end
+		: $now;
+
+	return array(
+		'per_hour'         => $per_hour,
+		'interval'         => $interval,
+		'current_slots'    => $current_slots,
+		'current_interval' => $current_interval,
+		'full_start'       => $full_start,
+	);
+}
+
+/**
+ * Schedules the next page fetch action with rate limiting.
+ *
+ * If budget is available, schedules soon. Otherwise, schedules at the
+ * start of the next budget window. If already scheduled more than an
+ * hour away, reschedules to an hour from now.
+ *
+ * @param string $hook The action hook name.
+ * @param array  $args The action arguments.
+ *
+ * @return int|null The action ID, or null if already pending.
+ */
+function schedule_next_page_fetch( $hook, $args ) {
+	$now        = time();
+	$window_end = get_transient( 'beer_slurper_api_window_end' );
+	$remaining  = get_remaining_budget();
+
+	if ( $remaining >= 1 ) {
+		// Budget available — schedule in 5 seconds.
+		$delay = 5;
+	} else {
+		// No budget — schedule at window reset.
+		$delay = $window_end ? max( 1, (int) $window_end - $now ) : HOUR_IN_SECONDS;
+	}
+
+	// Check if an action is already pending.
+	$existing = as_get_scheduled_actions( array(
+		'hook'     => $hook,
+		'args'     => $args,
+		'status'   => \ActionScheduler_Store::STATUS_PENDING,
+		'group'    => AS_GROUP,
+		'per_page' => 1,
+	), 'ids' );
+
+	if ( ! empty( $existing ) ) {
+		// Existing action found — check if it needs rescheduling.
+		global $wpdb;
+		$table = $wpdb->prefix . 'actionscheduler_actions';
+		$row   = $wpdb->get_row( $wpdb->prepare(
+			"SELECT action_id, scheduled_date_gmt FROM {$table} WHERE action_id = %d",
+			$existing[0]
+		) );
+
+		if ( $row ) {
+			$scheduled_time = strtotime( $row->scheduled_date_gmt . ' UTC' );
+			$one_hour_out   = $now + HOUR_IN_SECONDS;
+
+			// If scheduled more than an hour away and we have budget, pull it closer.
+			if ( $scheduled_time > $one_hour_out && $remaining >= 1 ) {
+				reschedule_action_by_id( $row->action_id, $now + 5 );
+			} elseif ( $scheduled_time > $one_hour_out && ! $remaining ) {
+				// No budget but scheduled too far — reschedule to window reset.
+				$reset_time = $window_end ? (int) $window_end : $one_hour_out;
+				reschedule_action_by_id( $row->action_id, $reset_time );
+			}
+		}
+		return null;
+	}
+
+	return schedule_action( $hook, $args, $delay );
+}
+
+/**
+ * Processes a single page of the prime-queue operation.
+ *
+ * Fetches one page of checkins from the API, queues them for processing,
+ * and schedules the next page if needed.
+ *
+ * @param string $user       The Untappd username.
+ * @param int    $page       Current page number (1-indexed).
+ * @param int    $max_pages  Maximum pages to fetch (0 = unlimited).
+ * @param string $session_id Unique session ID for this prime-queue run.
+ *
+ * @return void
+ */
+function process_prime_queue_page( $user, $page, $max_pages, $session_id ) {
+	$option_prefix = 'beer_slurper_' . $user;
+	$state_key     = 'beer_slurper_prime_state_' . $session_id;
+
+	// Initialize or retrieve session state.
+	$state = get_option( $state_key, array(
+		'total_fetched' => 0,
+		'total_queued'  => 0,
+		'started'       => time(),
+	) );
+
+	// Check budget.
+	if ( ! has_budget( 1 ) ) {
+		// Reschedule for next window.
+		schedule_next_page_fetch( 'bs_prime_queue_page', array(
+			'user'       => $user,
+			'page'       => $page,
+			'max_pages'  => $max_pages,
+			'session_id' => $session_id,
+		) );
+		return;
+	}
+
+	// Check page limit.
+	if ( $max_pages > 0 && $page > $max_pages ) {
+		finalize_prime_queue_session( $user, $state, $state_key, 'Reached page limit.' );
+		return;
+	}
+
+	$max_id   = get_option( $option_prefix . '_max' );
+	$checkins = \Kraft\Beer_Slurper\API\get_checkins( $user, $max_id, null, '25' );
+
+	if ( is_wp_error( $checkins ) ) {
+		error_log( 'Beer Slurper: prime-queue page ' . $page . ' API error: ' . $checkins->get_error_message() );
+		finalize_prime_queue_session( $user, $state, $state_key, 'API error: ' . $checkins->get_error_message() );
+		return;
+	}
+
+	if ( ! is_array( $checkins ) || ! isset( $checkins['checkins']['items'] ) || empty( $checkins['checkins']['items'] ) ) {
+		delete_option( $option_prefix . '_import' );
+		finalize_prime_queue_session( $user, $state, $state_key, 'Reached end of checkin history.' );
+		return;
+	}
+
+	$items = $checkins['checkins']['items'];
+	$count = count( $items );
+
+	// Update pagination cursor.
+	$new_max_id = $checkins['pagination']['max_id'] ?? null;
+	if ( $new_max_id ) {
+		update_option( $option_prefix . '_max', $new_max_id, false );
+	}
+
+	if ( ! get_option( $option_prefix . '_since' ) ) {
+		$since_url = wp_parse_args( parse_url( $checkins['pagination']['since_url'] ?? '', PHP_URL_QUERY ) );
+		$since_id  = isset( $since_url['min_id'] ) ? intval( $since_url['min_id'] ) : 0;
+		if ( $since_id ) {
+			update_option( $option_prefix . '_since', $since_id, false );
+		}
+	}
+
+	// Queue for processing — this also attaches companions via transients.
+	$queued = queue_checkin_batch( $items, 'import_old' );
+
+	// Also attach companions to any already-imported checkins found in this page.
+	attach_companions_to_existing( $items );
+
+	// Update state.
+	$state['total_fetched'] += $count;
+	$state['total_queued']  += $queued;
+	update_option( $state_key, $state, false );
+
+	// Check if we've reached the end.
+	if ( $count < 25 || empty( $new_max_id ) ) {
+		delete_option( $option_prefix . '_import' );
+		finalize_prime_queue_session( $user, $state, $state_key, 'Reached end of checkin history.' );
+		return;
+	}
+
+	// Schedule next page.
+	schedule_next_page_fetch( 'bs_prime_queue_page', array(
+		'user'       => $user,
+		'page'       => $page + 1,
+		'max_pages'  => $max_pages,
+		'session_id' => $session_id,
+	) );
+}
+add_action( 'bs_prime_queue_page', __NAMESPACE__ . '\process_prime_queue_page', 10, 4 );
+
+/**
+ * Attaches companions to already-imported checkins from a page of results.
+ *
+ * When fetching checkin history, some checkins may already be imported
+ * (from previous runs). This attaches their companions without re-importing.
+ *
+ * @param array $items Array of checkin data from the API.
+ *
+ * @return int Number of checkins that had companions attached.
+ */
+function attach_companions_to_existing( $items ) {
+	$attached = 0;
+
+	foreach ( $items as $checkin ) {
+		if ( empty( $checkin['checkin_id'] ) || empty( $checkin['tagged_friends']['items'] ) ) {
+			continue;
+		}
+
+		// Find the existing post for this checkin.
+		$post_id = \Kraft\Beer_Slurper\Post\find_existing_checkin( $checkin['checkin_id'] );
+		if ( ! $post_id ) {
+			continue;
+		}
+
+		// Attach companions.
+		\Kraft\Beer_Slurper\Companion\attach_companions( $checkin, $post_id );
+		$attached++;
+	}
+
+	return $attached;
+}
+
+/**
+ * Finalizes a prime-queue session and logs the result.
+ *
+ * @param string $user      The Untappd username.
+ * @param array  $state     Session state with totals.
+ * @param string $state_key Option key for the session state.
+ * @param string $reason    Reason for completion.
+ *
+ * @return void
+ */
+function finalize_prime_queue_session( $user, $state, $state_key, $reason ) {
+	$elapsed = time() - ( $state['started'] ?? time() );
+
+	error_log( sprintf(
+		'Beer Slurper: prime-queue complete for %s. %s Fetched %d checkins, queued %d in %d seconds.',
+		$user,
+		$reason,
+		$state['total_fetched'],
+		$state['total_queued'],
+		$elapsed
+	) );
+
+	delete_option( $state_key );
+}
+
+/**
+ * Processes a single page of the backfill-companions operation.
+ *
+ * Fetches one page of checkins from the API, matches to local posts,
+ * and attaches companions.
+ *
+ * @param string $user       The Untappd username.
+ * @param int    $page       Current page number (1-indexed).
+ * @param int    $max_pages  Maximum pages to fetch (0 = unlimited).
+ * @param string $session_id Unique session ID for this run.
+ * @param string $max_id     Pagination cursor (max_id from previous page).
+ *
+ * @return void
+ */
+function process_backfill_companions_page( $user, $page, $max_pages, $session_id, $max_id = null ) {
+	$state_key = 'beer_slurper_backfill_state_' . $session_id;
+
+	// Initialize or retrieve session state.
+	$state = get_option( $state_key, array(
+		'total_matched'    => 0,
+		'total_companions' => 0,
+		'total_attached'   => 0,
+		'total_skipped'    => 0,
+		'started'          => time(),
+		'checkin_lookup'   => null,
+	) );
+
+	// Build lookup on first page (or if not cached).
+	if ( null === $state['checkin_lookup'] ) {
+		global $wpdb;
+		$rows = $wpdb->get_results(
+			"SELECT c.comment_post_ID AS post_id, cm.meta_value AS checkin_id
+			FROM {$wpdb->comments} c
+			INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_id
+			WHERE c.comment_type = 'beer_checkin'
+			AND cm.meta_key = '_beer_slurper_checkin_id'"
+		);
+
+		$state['checkin_lookup'] = array();
+		foreach ( $rows as $row ) {
+			$state['checkin_lookup'][ $row->checkin_id ] = (int) $row->post_id;
+		}
+
+		if ( empty( $state['checkin_lookup'] ) ) {
+			error_log( 'Beer Slurper: backfill-companions - no local checkins found.' );
+			delete_option( $state_key );
+			return;
+		}
+
+		update_option( $state_key, $state, false );
+	}
+
+	// Check budget.
+	if ( ! has_budget( 1 ) ) {
+		schedule_next_page_fetch( 'bs_backfill_companions_page', array(
+			'user'       => $user,
+			'page'       => $page,
+			'max_pages'  => $max_pages,
+			'session_id' => $session_id,
+			'max_id'     => $max_id,
+		) );
+		return;
+	}
+
+	// Check page limit.
+	if ( $max_pages > 0 && $page > $max_pages ) {
+		finalize_backfill_companions_session( $user, $state, $state_key, 'Reached page limit.' );
+		return;
+	}
+
+	$response = \Kraft\Beer_Slurper\API\get_checkins( $user, $max_id, null, '25' );
+
+	if ( is_wp_error( $response ) ) {
+		error_log( 'Beer Slurper: backfill-companions page ' . $page . ' API error: ' . $response->get_error_message() );
+		finalize_backfill_companions_session( $user, $state, $state_key, 'API error: ' . $response->get_error_message() );
+		return;
+	}
+
+	if ( ! is_array( $response ) || empty( $response['checkins']['items'] ) ) {
+		finalize_backfill_companions_session( $user, $state, $state_key, 'Reached end of checkin history.' );
+		return;
+	}
+
+	$items = $response['checkins']['items'];
+	$count = count( $items );
+
+	foreach ( $items as $checkin ) {
+		$cid = (string) ( $checkin['checkin_id'] ?? '' );
+
+		if ( ! isset( $state['checkin_lookup'][ $cid ] ) ) {
+			continue;
+		}
+
+		$post_id = $state['checkin_lookup'][ $cid ];
+		$state['total_matched']++;
+
+		if ( empty( $checkin['tagged_friends']['items'] ) ) {
+			continue;
+		}
+
+		$friend_count = count( $checkin['tagged_friends']['items'] );
+		$state['total_companions'] += $friend_count;
+
+		// Try to attach each companion and track success/failure.
+		$attached_this = 0;
+		foreach ( $checkin['tagged_friends']['items'] as $item ) {
+			if ( empty( $item['user']['uid'] ) ) {
+				$state['total_skipped']++;
+				continue;
+			}
+
+			$term_id = \Kraft\Beer_Slurper\Companion\get_companion_term_id( $item['user']['uid'], $item['user'] );
+			if ( $term_id ) {
+				wp_set_object_terms( $post_id, (int) $term_id, BEER_SLURPER_TAX_COMPANION, true );
+				$attached_this++;
+			} else {
+				$state['total_skipped']++;
+				// Log the failure for debugging.
+				error_log( sprintf(
+					'Beer Slurper: Failed to create companion for uid %s (user_name: %s) on checkin %s',
+					$item['user']['uid'] ?? 'unknown',
+					$item['user']['user_name'] ?? 'missing',
+					$cid
+				) );
+			}
+		}
+		$state['total_attached'] += $attached_this;
+	}
+
+	update_option( $state_key, $state, false );
+
+	// Update pagination cursor.
+	$new_max_id = $response['pagination']['max_id'] ?? null;
+
+	if ( $count < 25 || empty( $new_max_id ) ) {
+		finalize_backfill_companions_session( $user, $state, $state_key, 'Reached end of checkin history.' );
+		return;
+	}
+
+	// Schedule next page.
+	schedule_next_page_fetch( 'bs_backfill_companions_page', array(
+		'user'       => $user,
+		'page'       => $page + 1,
+		'max_pages'  => $max_pages,
+		'session_id' => $session_id,
+		'max_id'     => $new_max_id,
+	) );
+}
+add_action( 'bs_backfill_companions_page', __NAMESPACE__ . '\process_backfill_companions_page', 10, 5 );
+
+/**
+ * Finalizes a backfill-companions session and logs the result.
+ *
+ * @param string $user      The Untappd username.
+ * @param array  $state     Session state with totals.
+ * @param string $state_key Option key for the session state.
+ * @param string $reason    Reason for completion.
+ *
+ * @return void
+ */
+function finalize_backfill_companions_session( $user, $state, $state_key, $reason ) {
+	$elapsed = time() - ( $state['started'] ?? time() );
+
+	error_log( sprintf(
+		'Beer Slurper: backfill-companions complete for %s. %s Matched %d checkins, found %d companions, attached %d, skipped %d in %d seconds.',
+		$user,
+		$reason,
+		$state['total_matched'],
+		$state['total_companions'],
+		$state['total_attached'],
+		$state['total_skipped'],
+		$elapsed
+	) );
+
+	delete_option( $state_key );
+}
+
+/**
  * Cleans up all Action Scheduler actions on deactivation or reset.
  *
  * @return void
@@ -817,6 +1269,8 @@ function cleanup() {
 
 	cancel_all( 'bs_process_checkin' );
 	cancel_all( 'bs_backfill_companion' );
+	cancel_all( 'bs_prime_queue_page' );
+	cancel_all( 'bs_backfill_companions_page' );
 	cancel_all( 'bs_hourly_import' );
 	cancel_all( 'bs_daily_maintenance' );
 	cancel_all( 'bs_maintenance_stats' );
@@ -828,4 +1282,9 @@ function cleanup() {
 
 	// Legacy hook names from older versions.
 	cancel_all( 'bs_as_daily_maintenance' );
+
+	// Clean up any session state options.
+	global $wpdb;
+	$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE 'beer_slurper_prime_state_%'" );
+	$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE 'beer_slurper_backfill_state_%'" );
 }

--- a/includes/functions/queue.php
+++ b/includes/functions/queue.php
@@ -1043,29 +1043,45 @@ add_action( 'bs_prime_queue_page', __NAMESPACE__ . '\process_prime_queue_page', 
 function attach_companions_to_existing( $items ) {
 	$attached = 0;
 
+	// Collect checkin IDs that have companions to attach.
+	$checkins_with_companions = array();
 	foreach ( $items as $checkin ) {
-		if ( empty( $checkin['checkin_id'] ) || empty( $checkin['tagged_friends']['items'] ) ) {
+		if ( ! empty( $checkin['checkin_id'] ) && ! empty( $checkin['tagged_friends']['items'] ) ) {
+			$checkins_with_companions[ $checkin['checkin_id'] ] = $checkin;
+		}
+	}
+
+	if ( empty( $checkins_with_companions ) ) {
+		return 0;
+	}
+
+	// Batch query: find all matching posts in a single query.
+	global $wpdb;
+	$checkin_ids = array_keys( $checkins_with_companions );
+	$placeholders = implode( ',', array_fill( 0, count( $checkin_ids ), '%s' ) );
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- placeholders are safe
+	$results = $wpdb->get_results( $wpdb->prepare(
+		"SELECT post_id, meta_value AS checkin_id
+		FROM {$wpdb->postmeta}
+		WHERE meta_key = '_beer_slurper_untappd_id'
+		AND meta_value IN ($placeholders)",
+		...$checkin_ids
+	) );
+
+	// Build lookup: checkin_id => post_id.
+	$checkin_to_post = array();
+	foreach ( $results as $row ) {
+		$checkin_to_post[ $row->checkin_id ] = (int) $row->post_id;
+	}
+
+	// Attach companions using the lookup.
+	foreach ( $checkins_with_companions as $checkin_id => $checkin ) {
+		if ( ! isset( $checkin_to_post[ $checkin_id ] ) ) {
 			continue;
 		}
 
-		// Find the existing post for this checkin via direct query.
-		// find_existing_checkin() returns boolean, so we query for post_id directly.
-		$posts = get_posts( array(
-			'post_type'      => BEER_SLURPER_CPT,
-			'posts_per_page' => 1,
-			'fields'         => 'ids',
-			'meta_key'       => '_beer_slurper_untappd_id',
-			'meta_value'     => $checkin['checkin_id'],
-		) );
-
-		if ( empty( $posts ) ) {
-			continue;
-		}
-
-		$post_id = $posts[0];
-
-		// Attach companions.
-		\Kraft\Beer_Slurper\Companion\attach_companions( $checkin, $post_id );
+		\Kraft\Beer_Slurper\Companion\attach_companions( $checkin, $checkin_to_post[ $checkin_id ] );
 		$attached++;
 	}
 

--- a/includes/functions/queue.php
+++ b/includes/functions/queue.php
@@ -872,6 +872,10 @@ function get_page_spread_params() {
  * @return int|null The action ID, or null if already pending.
  */
 function schedule_next_page_fetch( $hook, $args ) {
+	if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
+		return null;
+	}
+
 	$now        = time();
 	$window_end = get_transient( 'beer_slurper_api_window_end' );
 	$remaining  = get_remaining_budget();
@@ -1041,11 +1045,21 @@ function attach_companions_to_existing( $items ) {
 			continue;
 		}
 
-		// Find the existing post for this checkin.
-		$post_id = \Kraft\Beer_Slurper\Post\find_existing_checkin( $checkin['checkin_id'] );
-		if ( ! $post_id ) {
+		// Find the existing post for this checkin via direct query.
+		// find_existing_checkin() returns boolean, so we query for post_id directly.
+		$posts = get_posts( array(
+			'post_type'      => BEER_SLURPER_CPT,
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'meta_key'       => '_beer_slurper_untappd_id',
+			'meta_value'     => $checkin['checkin_id'],
+		) );
+
+		if ( empty( $posts ) ) {
 			continue;
 		}
+
+		$post_id = $posts[0];
 
 		// Attach companions.
 		\Kraft\Beer_Slurper\Companion\attach_companions( $checkin, $post_id );

--- a/tests/phpunit/Companion_Tests.php
+++ b/tests/phpunit/Companion_Tests.php
@@ -78,19 +78,27 @@ class Companion_Tests extends Base\TestCase {
 	}
 
 	/**
-	 * Tests add_companion() returns false without user data.
+	 * Tests add_companion() creates placeholder term without user data.
 	 */
-	public function test_add_companion_returns_false_without_data() {
-		$result = add_companion( 12345, null );
-		$this->assertFalse( $result );
+	public function test_add_companion_creates_placeholder_without_data() {
+		$term_id = add_companion( 12345, null );
+		$this->assertIsInt( $term_id );
+
+		$term = get_term( $term_id, BEER_SLURPER_TAX_COMPANION );
+		$this->assertEquals( 'Untappd User 12345', $term->name );
+		$this->assertEquals( 'untappd-user-12345', $term->slug );
 	}
 
 	/**
-	 * Tests add_companion() returns false without username.
+	 * Tests add_companion() creates placeholder term without username.
 	 */
-	public function test_add_companion_returns_false_without_username() {
-		$result = add_companion( 12345, array( 'uid' => 12345 ) );
-		$this->assertFalse( $result );
+	public function test_add_companion_creates_placeholder_without_username() {
+		$term_id = add_companion( 67890, array( 'uid' => 67890 ) );
+		$this->assertIsInt( $term_id );
+
+		$term = get_term( $term_id, BEER_SLURPER_TAX_COMPANION );
+		$this->assertEquals( 'Untappd User 67890', $term->name );
+		$this->assertEquals( 'untappd-user-67890', $term->slug );
 	}
 
 	/**

--- a/tests/phpunit/Queue_Tests.php
+++ b/tests/phpunit/Queue_Tests.php
@@ -301,4 +301,115 @@ class Queue_Tests extends Base\TestCase {
 			$this->markTestSkipped( 'Action Scheduler is loaded.' );
 		}
 	}
+
+	/**
+	 * Tests get_page_spread_params() returns expected structure.
+	 */
+	public function test_get_page_spread_params_returns_structure() {
+		$params = get_page_spread_params();
+
+		$this->assertArrayHasKey( 'per_hour', $params );
+		$this->assertArrayHasKey( 'interval', $params );
+		$this->assertArrayHasKey( 'current_slots', $params );
+		$this->assertArrayHasKey( 'current_interval', $params );
+		$this->assertArrayHasKey( 'full_start', $params );
+	}
+
+	/**
+	 * Tests get_page_spread_params() calculates per_hour for single API call cost.
+	 */
+	public function test_get_page_spread_params_calculates_per_hour() {
+		$params = get_page_spread_params();
+
+		// At 1 call per page, 90 budget = 90 per hour
+		$this->assertEquals( 90, $params['per_hour'] );
+	}
+
+	/**
+	 * Tests get_page_spread_params() calculates current_slots with budget.
+	 */
+	public function test_get_page_spread_params_current_slots_with_budget() {
+		set_transient( 'beer_slurper_api_calls', 0, HOUR_IN_SECONDS );
+		set_transient( 'beer_slurper_api_window_end', time() + 1800, HOUR_IN_SECONDS ); // 30 min left
+
+		$params = get_page_spread_params();
+
+		// With full budget and 30 min left, should have slots available
+		$this->assertGreaterThan( 0, $params['current_slots'] );
+	}
+
+	/**
+	 * Tests get_page_spread_params() returns zero current_slots when budget exhausted.
+	 */
+	public function test_get_page_spread_params_no_slots_when_exhausted() {
+		set_transient( 'beer_slurper_api_calls', 90, HOUR_IN_SECONDS );
+		set_transient( 'beer_slurper_api_window_end', time() + 1800, HOUR_IN_SECONDS );
+
+		$params = get_page_spread_params();
+
+		$this->assertEquals( 0, $params['current_slots'] );
+	}
+
+	/**
+	 * Tests schedule_next_page_fetch() returns null without Action Scheduler.
+	 */
+	public function test_schedule_next_page_fetch_without_as() {
+		if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
+			$result = schedule_next_page_fetch( 'test_hook', array() );
+			$this->assertNull( $result );
+		} else {
+			$this->markTestSkipped( 'Action Scheduler is loaded.' );
+		}
+	}
+
+	/**
+	 * Tests attach_companions_to_existing() returns 0 for empty items.
+	 */
+	public function test_attach_companions_to_existing_empty_items() {
+		$result = attach_companions_to_existing( array() );
+
+		$this->assertEquals( 0, $result );
+	}
+
+	/**
+	 * Tests attach_companions_to_existing() skips items without checkin_id.
+	 */
+	public function test_attach_companions_to_existing_skips_without_checkin_id() {
+		$items = array(
+			array( 'tagged_friends' => array( 'items' => array( array( 'user' => array( 'uid' => 123 ) ) ) ) ),
+		);
+
+		$result = attach_companions_to_existing( $items );
+
+		$this->assertEquals( 0, $result );
+	}
+
+	/**
+	 * Tests attach_companions_to_existing() skips items without tagged_friends.
+	 */
+	public function test_attach_companions_to_existing_skips_without_friends() {
+		$items = array(
+			array( 'checkin_id' => 12345 ),
+		);
+
+		$result = attach_companions_to_existing( $items );
+
+		$this->assertEquals( 0, $result );
+	}
+
+	/**
+	 * Tests attach_companions_to_existing() skips non-existent checkins.
+	 */
+	public function test_attach_companions_to_existing_skips_nonexistent() {
+		$items = array(
+			array(
+				'checkin_id'      => 99999999,
+				'tagged_friends'  => array( 'items' => array( array( 'user' => array( 'uid' => 123 ) ) ) ),
+			),
+		);
+
+		$result = attach_companions_to_existing( $items );
+
+		$this->assertEquals( 0, $result );
+	}
 }


### PR DESCRIPTION
- Add Action Scheduler handlers for rate-limited page fetching
- Both commands now schedule pages via AS by default (use --sync for old behavior)
- prime-queue also attaches companions to already-imported checkins
- Fix add_companion() to handle missing user_name gracefully (uses UID fallback)
- Add detailed logging for backfill-companions debugging
- Update cleanup() to cancel new action hooks

This prevents overwhelming the API budget when running these commands.
Pages are spread across hourly windows at 90 pages/hour rate.

https://claude.ai/code/session_01TKYCG3TyGzEhJVJraKjaMt